### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 beir==2.0.0
 tensorflow_text==2.15.0
 sentence-transformers==2.2.2
-scispacy
-spacy
+scispacy=0.5.2
+spacy=3.4.4
 spacy-transformers
 googletrans==3.1.0a0
 sentence_splitter


### PR DESCRIPTION
scispacy 0.5.4 requires spacy<3.8.0,>=3.7.0
en-core-sci-scibert 0.5.1 requires spacy<3.5.0,>=3.4.1
Therefore, the version of scispacy needs to be specified as 0.5.2.